### PR TITLE
Markdown titles bugfix

### DIFF
--- a/node/generate.go
+++ b/node/generate.go
@@ -92,24 +92,6 @@ func (node *Node) generateFolderPage() error {
 	return nil
 }
 
-/* DISABLED FOR NOW
-// generateTODOPage method creates a page in parent folder
-// that contains todo's for a codebase
-func (node *Node) generateTODOPage(percentage string) {
-	todonode := Node{}
-	todonode.root = node
-
-	page := todo.GenerateTODO(rootDir, percentage)
-
-	if page != nil {
-		err := todonode.checkConfluencePages(page)
-		if err != nil {
-			log.Println(err)
-		}
-	}
-}
-*/
-
 // generateTitles returns two strings
 // string 1 - folder of the node
 // string 2 - the absolute filepath to the node dir from root dir

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -23,7 +23,7 @@ func TestStartAlreadyExists(t *testing.T) {
 
 	gomock.InOrder(
 		client.EXPECT().FindPage("node", false).Times(1).Return(&results, nil),
-		client.EXPECT().FindPage("markdown-to-confluence/node+readme", false).Times(1).Return(&results, nil),
+		client.EXPECT().FindPage("markdown-to-confluence/node+readme-node-node", false).Times(1).Return(&results, nil),
 		client.EXPECT().CreatePage(0, &page, true).Times(1).Return(0, nil),
 	)
 
@@ -45,7 +45,7 @@ func TestStartBrandNew(t *testing.T) {
 	}
 	readmePage := markdown.FileContents{
 		MetaData: map[string]interface{}{
-			"title": "markdown-to-confluence/node readme",
+			"title": "markdown-to-confluence/node readme-node-node",
 		},
 		Body: []byte(`<h1>markdown-to-confluence/node readme</h1>
 <h2>the node package is to enable reading through a repo and create a tree of content on confluence</h2>
@@ -73,7 +73,7 @@ Delete()
 	gomock.InOrder(
 		client.EXPECT().FindPage("node", false).Times(1).Return(nil, nil),
 		client.EXPECT().CreatePage(0, &nodePage, true).Times(1).Return(0, nil),
-		client.EXPECT().FindPage("markdown-to-confluence/node+readme", false).Times(1).Return(nil, nil),
+		client.EXPECT().FindPage("markdown-to-confluence/node+readme-node-node", false).Times(1).Return(nil, nil),
 		client.EXPECT().CreatePage(0, &readmePage, false).Times(1).Return(0, nil),
 	)
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	common "github.com/xiatechs/markdown-to-confluence/common"
 	confluence "github.com/xiatechs/markdown-to-confluence/confluence"
 	markdown "github.com/xiatechs/markdown-to-confluence/markdown"
 )
@@ -24,7 +23,6 @@ func TestStartAlreadyExists(t *testing.T) {
 
 	gomock.InOrder(
 		client.EXPECT().FindPage("node", false).Times(1).Return(&results, nil),
-		client.EXPECT().FindPage("plantuml-node", false).Times(1).Return(&results, nil),
 		client.EXPECT().FindPage("markdown-to-confluence/node+readme", false).Times(1).Return(&results, nil),
 		client.EXPECT().CreatePage(0, &page, true).Times(1).Return(0, nil),
 	)
@@ -46,14 +44,6 @@ func TestStartBrandNew(t *testing.T) {
 <p>You will find attachments/images for this folder via the ellipsis at the top right.</p>
 <p>Any markdown or subfolders is available in children pages under this page.</p>`),
 	}
-
-	plantumlPage := markdown.FileContents{
-		MetaData: map[string]interface{}{
-			"title": "plantuml-node",
-		},
-		Body: []byte(`<p><span class="confluence-embedded-file-wrapped"><img src="` + common.ConfluenceBaseURL + `/wiki/download/attachments/0/node-pumldiagram.png"></img></span></p>`),
-	}
-
 	readmePage := markdown.FileContents{
 		MetaData: map[string]interface{}{
 			"title": "markdown-to-confluence/node readme",
@@ -84,8 +74,6 @@ Delete()
 	gomock.InOrder(
 		client.EXPECT().FindPage("node", false).Times(1).Return(nil, nil),
 		client.EXPECT().CreatePage(0, &nodePage, true).Times(1).Return(0, nil),
-		client.EXPECT().FindPage("plantuml-node", false).Times(1).Return(nil, nil),
-		client.EXPECT().CreatePage(0, &plantumlPage, false).Times(1).Return(0, nil),
 		client.EXPECT().FindPage("markdown-to-confluence/node+readme", false).Times(1).Return(nil, nil),
 		client.EXPECT().CreatePage(0, &readmePage, false).Times(1).Return(0, nil),
 	)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -30,7 +30,6 @@ func TestStartAlreadyExists(t *testing.T) {
 	node.Start("../node")
 }
 
-//nolint: lll // test function with test contents
 func TestStartBrandNew(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	client := NewMockAPIClienter(ctrl)

--- a/node/process.go
+++ b/node/process.go
@@ -45,6 +45,10 @@ func (node *Node) processMarkDown(path string) error {
 		return fmt.Errorf("parse markdown error: %w", err)
 	}
 
+	extraDetails, _ := node.generateTitles()
+
+	parsedContents.MetaData["title"] = parsedContents.MetaData["title"].(string) + "-" + extraDetails
+
 	err = node.checkConfluencePages(parsedContents)
 	if err != nil {
 		log.Printf("error completing confluence operations: %s", err)


### PR DESCRIPTION
- [x] Tests for the changes have been added (for bug fixes / features)

- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

**Confluence API only lets you create a page using title - and page names _need_ to be unique within a space for pages to coexist.
This is a limitation of the CONFLUENCE API and thus not something that this tool can overcome - as it uses the confluence API**

SO...

I have implemented a solution where not only the title is saved, but the foldername of folder the file is contained in, and the title page. This adds enough uniqueness to page title.

**What is the current behavior?** (You can also link to an open issue here)

markdown page titles are not unique enough, duplicate names mean pages are not created (spotted this bug when MTC was used on flying tiger repository)

**What is the new behavior (if this is a feature change)?**

if there's a page with title 'Simple' and it's within the folder 'testfolder' within the repository 'testrepo'
With this bugfix, the page title will now be Simple-testfolder-testrepo
Beforehand, it was just 'Simple'.

This means that if there's two folders i.e testfolder and testfolder1 within testrepo, and a page within each folder with title 'Simple'
instead of having page collision, you get two pages:

Simple-testfolder-testrepo
Simple-testfolder1-testrepo

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

//

**Further Information**

Please also include relevant motivation and context.
List any dependencies that are required for this change.
