### PR TITLE
bug fix for when 2 relative links appear on the same line

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,4 +31,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.50.1
+          version: v1.51.2

--- a/Configuration-Guide.md
+++ b/Configuration-Guide.md
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2-beta
         with:
           repository: xiatechs/markdown-to-confluence
-          ref: refs/tags/v1.10
+          ref: refs/tags/v2.1.2
       - name: checkout branch
         uses: actions/checkout@v2
         with:

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -437,7 +437,7 @@ func generateRelativeURLs(sliceOne []string, abs, fileName string) ([]string, []
 		if localLink != "" {
 			// as there is a local link the path must be in a .md file
 			// can either be in a .md file OR a README.md (this would not have .md in the confluence page name)
-			// if the updated url does not contain a .md and the fileName does
+			// if the updated URL does not contain a .md and the fileName does
 			// then it must be a local link for the current .md file so add it
 			if !strings.Contains(updatedURL, ".md") {
 				if strings.Contains(fileName, ".md") {

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -403,51 +403,71 @@ func relativeURLdetector(item string, page map[string]string, abs, fileName stri
 		return fail
 	}
 
-	url := strings.Split(sliceOne[1], `"`)[0] // the local/relative URL for the page
-
-	// create the absolute url
-	updatedURL, localLink := convertRelativeToAbsoluteURL(abs, url)
-
-	// confluence is case sensitive - headers are saved using proper case (i.e. So The Title Is Always Like This)
-	caser := cases.Title(language.English)
-	localLink = caser.String(localLink)
-
-	var link string
-
-	// if there were any local links (identified by #) then create the link for confluence
-	if localLink != "" {
-		// as there is a local link the path must be in a .md file
-		// can either be in a .md file OR a README.md (this would not have .md in the confluence page name)
-		// if the updated url does not contain a .md and the fileName does
-		// then it must be a local link for the current .md file so add it
-		if !strings.Contains(updatedURL, ".md") {
-			if strings.Contains(fileName, ".md") {
-				updatedURL += "/" + fileName
-			}
-		}
-
-		fileName = strings.ReplaceAll(fileName, " ", "+")
-		localLinkAbs := strings.ReplaceAll(abs, "/", "+")
-
-		link = "/" + fileName
-		if !strings.HasPrefix(localLinkAbs, "+") {
-			link += "+"
-		}
-
-		link += localLinkAbs + "#" + localLink
-	}
+	updatedURLs, links := generateRelativeURLs(sliceOne, abs, fileName)
 
 	// replace the relative url in the item with the absolute url
 	splitItem := strings.Split(item, "<a href=")
 
-	return generateLineToReturn(updatedURL, link, splitItem, page)
+	return generateLineToReturn(updatedURLs, links, splitItem, page)
 }
 
-func generateLineToReturn(updatedURL, link string, splitItem []string, page map[string]string) string {
+func generateRelativeURLs(sliceOne []string, abs, fileName string) ([]string, []string) {
+	var (
+		updatedURLs []string
+		links       []string
+	)
+
+	for i := range sliceOne {
+		if i == 0 {
+			continue
+		}
+
+		url := strings.Split(sliceOne[i], `"`)[0] // the local/relative URL for the page
+
+		// create the absolute url
+		updatedURL, localLink := convertRelativeToAbsoluteURL(abs, url)
+
+		// confluence is case sensitive - headers are saved using proper case (i.e. So The Title Is Always Like This)
+		caser := cases.Title(language.English)
+		localLink = caser.String(localLink)
+
+		var link string
+
+		// if there were any local links (identified by #) then create the link for confluence
+		if localLink != "" {
+			// as there is a local link the path must be in a .md file
+			// can either be in a .md file OR a README.md (this would not have .md in the confluence page name)
+			// if the updated url does not contain a .md and the fileName does
+			// then it must be a local link for the current .md file so add it
+			if !strings.Contains(updatedURL, ".md") {
+				if strings.Contains(fileName, ".md") {
+					updatedURL += "/" + fileName
+				}
+			}
+
+			fileName = strings.ReplaceAll(fileName, " ", "+")
+			localLinkAbs := strings.ReplaceAll(abs, "/", "+")
+
+			link = "/" + fileName
+			if !strings.HasPrefix(localLinkAbs, "+") {
+				link += "+"
+			}
+
+			link += localLinkAbs + "#" + localLink
+		}
+
+		updatedURLs = append(updatedURLs, updatedURL)
+		links = append(links, link)
+	}
+
+	return updatedURLs, links
+}
+
+func generateLineToReturn(updatedURL, link []string, splitItem []string, page map[string]string) string {
 	stringToReturn := splitItem[0]
 
 	for i := 1; i < len(splitItem); i++ {
-		link := generateLink(page, updatedURL, link)
+		link := generateLink(page, updatedURL[i-1], link[i-1])
 		extraParts := strings.SplitN(splitItem[i], ">", 2) //nolint:gomnd // only want to split the final part on the first >
 
 		stringToReturn += link

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -463,11 +463,11 @@ func generateRelativeURLs(sliceOne []string, abs, fileName string) ([]string, []
 	return updatedURLs, links
 }
 
-func generateLineToReturn(updatedURL, link []string, splitItem []string, page map[string]string) string {
+func generateLineToReturn(updatedURL, links []string, splitItem []string, page map[string]string) string {
 	stringToReturn := splitItem[0]
 
 	for i := 1; i < len(splitItem); i++ {
-		link := generateLink(page, updatedURL[i-1], link[i-1])
+		link := generateLink(page, updatedURL[i-1], links[i-1])
 		extraParts := strings.SplitN(splitItem[i], ">", 2) //nolint:gomnd // only want to split the final part on the first >
 
 		stringToReturn += link

--- a/node/check.go
+++ b/node/check.go
@@ -97,8 +97,6 @@ func (node *Node) checkIfMarkDownFile(checking bool, name string) bool {
 			return true
 		}
 
-		foldersWithMarkdown++
-
 		return true
 	}
 
@@ -109,8 +107,6 @@ func (node *Node) checkIfMarkDownFile(checking bool, name string) bool {
 // and returns bool
 func (node *Node) checkIfFolder(fpath string) bool {
 	if isFolder(fpath) && !isVendorOrGit(fpath) {
-		numberOfFolders++
-
 		node.checkIfRootAlive(fpath)
 
 		return true

--- a/node/generate.go
+++ b/node/generate.go
@@ -29,8 +29,7 @@ func (node *Node) generateMaster() {
 
 		// we only want to read from the repo/docs folder
 		// so if there is at least 1 sub folder and it is not /docs ignore
-		if len(listOfFolders) > 1 && !strings.Contains(node.path, "/docs") &&
-			node.path != "/home/cameron/go_projects/xiatechs/mossbros" {
+		if len(listOfFolders) > 1 && !strings.Contains(node.path, "/docs") {
 			log.Printf("skipping this folder [%s] because not in the /docs folder", node.path)
 
 			return

--- a/node/generate.go
+++ b/node/generate.go
@@ -29,7 +29,8 @@ func (node *Node) generateMaster() {
 
 		// we only want to read from the repo/docs folder
 		// so if there is at least 1 sub folder and it is not /docs ignore
-		if len(listOfFolders) > 1 && !strings.Contains(node.path, "/docs") {
+		if len(listOfFolders) > 1 && !strings.Contains(node.path, "/docs") &&
+			node.path != "/home/cameron/go_projects/xiatechs/mossbros" {
 			log.Printf("skipping this folder [%s] because not in the /docs folder", node.path)
 
 			return

--- a/node/node.go
+++ b/node/node.go
@@ -20,11 +20,9 @@ const (
 )
 
 var (
-	mapSem              = make(chan struct{}, 1)                   // for controlling access to Tree map
-	wg                  = semaphore.NewSemaphore(numberOfRoutines) // for controlling number of goroutines
-	numberOfFolders     float64                                    // for counting number of folders in repo
-	foldersWithMarkdown float64                                    // for counting number of folders with markdown in repo
-	rootDir             string                                     // will contain the root folderpath of the repo
+	mapSem  = make(chan struct{}, 1)                   // for controlling access to Tree map
+	wg      = semaphore.NewSemaphore(numberOfRoutines) // for controlling number of goroutines
+	rootDir string                                     // will contain the root folderpath of the repo
 	// NodeAPIClient is interface where a confluence API client can be placed
 	nodeAPIClient APIClienter // api client will be stored here
 	t             *Tree
@@ -92,8 +90,6 @@ func (node *Node) Start(projectMasterID int, projectPath string, onlyDocs bool) 
 	*/
 
 	if isFolder(projectPath) {
-		numberOfFolders++
-
 		node.masterID = projectMasterID
 
 		node.path = projectPath

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -25,7 +25,7 @@ func TestStartDebugEverything(t *testing.T) {
 
 	// t.Skip() // skip test as concurrency means it fails - only used locally for debugging
 
-	if node.Start(0, "/home/cameron/go_projects/xiatechs/mossbros", false) {
+	if node.Start(0, "../node", false) {
 		node.Delete()
 	}
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -23,9 +23,9 @@ func TestStartDebugEverything(t *testing.T) {
 
 	SetAPIClient(m)
 
-	t.Skip() // skip test as concurrency means it fails - only used locally for debugging
+	// t.Skip() // skip test as concurrency means it fails - only used locally for debugging
 
-	if node.Start(0, "../node", false) {
+	if node.Start(0, "/home/cameron/go_projects/xiatechs/mossbros", false) {
 		node.Delete()
 	}
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -11,6 +11,8 @@ import (
 // this test lets you see visually how all the content is generated in case you want to debug the output locally
 // basically run it against any path you want and you'll see the pages generated at the end - after logging
 func TestStartDebugEverything(t *testing.T) {
+	t.Skip() // skip test as concurrency means it fails - only used locally for debugging
+
 	markdown.GrabAuthors = false
 
 	node := Node{
@@ -22,8 +24,6 @@ func TestStartDebugEverything(t *testing.T) {
 	}
 
 	SetAPIClient(m)
-
-	t.Skip() // skip test as concurrency means it fails - only used locally for debugging
 
 	if node.Start(0, "../node", false) {
 		node.Delete()

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -23,7 +23,7 @@ func TestStartDebugEverything(t *testing.T) {
 
 	SetAPIClient(m)
 
-	// t.Skip() // skip test as concurrency means it fails - only used locally for debugging
+	t.Skip() // skip test as concurrency means it fails - only used locally for debugging
 
 	if node.Start(0, "../node", false) {
 		node.Delete()

--- a/node/testfolder/file/downhere/readme.md
+++ b/node/testfolder/file/downhere/readme.md
@@ -4,3 +4,13 @@
 
 this readme should be the index of a folder with another file in
 it called 'file-within-readme' or something similar
+
+this is an example line with 2 relative links - [readme.md at the above level](../../readme.md) and [link to hello.md](./hello.md).
+
+this is an example of a relative link within the [same file](#section-2).
+
+this is an example of a relative link to a header within a [different file](../../../readme.md#the-package-contains-two-exported-methods:).
+
+## section 2
+
+A new section of the markdown file

--- a/node/testfolder/readme.md
+++ b/node/testfolder/readme.md
@@ -5,7 +5,7 @@ confluence absolute links - as if by magic.
 
 [lower level relative link](./file/downhere/hello.md)
 
-[test markdown folder](../testfolder/testmarkdown.md)
+[node markdown folder](../readme.md)
 
 using fuzzy logic the links above to re-jigged to align with their correct source.
 it's not 100% foolproof but hey it's better than nothing, right?


### PR DESCRIPTION
If a line has 2 relative links on it currently they will both be created in confluence with the first link

Fix will ensure confluence is created with the 2 links created correctly

Bumped the linter also